### PR TITLE
Set visu step and output folder stratigraphy

### DIFF
--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -64,6 +64,8 @@ namespace aspect
     // Functions to run FastScape
     void fastscape_get_step_(int *sstep);
     void fastscape_execute_step_();
+    // Set the output file directory and visualization step
+    void folder_output_(int *length, int *asetp, const char *c);
     // Create a visualization file into the ASPECT/VTK folder
     void fastscape_named_vtk_(double *fp, const double *vexp, int *astep, const char *c, int *length);
     // Copy the height array from FastScape back into ASPECT.

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -668,12 +668,19 @@ namespace aspect
                  * run for, need to figure out how to work this in better.
                  */
                 if (use_strat && current_timestep == 1)
-                  fastscape_strati_(&nstepp, &nreflectorp, &steps, &vexp);
+                  {
+                    // Folder_output (k, istep, foldername)
+                    folder_output_(&length, &visualization_step, c);
+                    fastscape_strati_(&nstepp, &nreflectorp, &steps, &vexp);
+                  }
                 else if (!use_strat && current_timestep == 1)
                   {
                     this->get_pcout() << "      Writing initial VTK..." << std::endl;
                     // Note: Here, the HHHHH field in visualization is set to show the diffusivity. However, you can change this so any parameter
                     // is visualized.
+                    // TODO why is this output step skipped when use_strat = true,
+                    // but not in subsequent timepsteps (line 707).
+                    // Fastscape_Named_VTK (f, vex, istep, foldername, k)
                     fastscape_named_vtk_(kd.get(), &vexp, &visualization_step, c, &length);
                   }
 


### PR DESCRIPTION
This PR provides the folder name to FastScape so that VTK output is created when the Stratigraphy subroutine is used. This fixes FastScape crashing because it cannot create a folder or VTK file in that folder. 

### For all pull requests:

* [ ] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
